### PR TITLE
Allow missing trailing comma

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ macro_rules! multi_structs {
                 )+
             }
         )+
-        
+
         $(#[$($meta)+])*
         pub struct $name {
             $(
@@ -99,7 +99,7 @@ macro_rules! multi_structs {
                 )+
             )+
         }
-        
+
         impl $name {
             /// Create $name.
             pub fn new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,8 +74,8 @@ macro_rules! multi_structs {
                 $var:ident: struct $sub:ident {
                     $(
                         $(#[$($field_meta:tt)+])*
-                        $field:ident: $ty:ty,
-                    )+
+                        $field:ident: $ty:ty
+                    ),+ $(,)?
                 }
             )+
         }


### PR DESCRIPTION
This pull request enables trailing commas in sub-structs to be optional. Before, the following failed:

```rust
use multi_structs::multi_structs;

multi_structs! {
    #[derive(Debug)]
    struct Merged {
        #[derive(Debug)]
        foo: struct Foo {
            a: i32,
            // ------------------- trailing comma removed -----------
            b: i64
        }
        /// Bar
        #[derive(Debug)]
        bar: struct Bar {
            c: usize,
            d: String,
        }
    }
}

fn main() {
    let foo = Foo { a: 1, b: 2 };
    let bar = Bar { c: 3, d: "aaa".to_string() };
    println!("{:?}, {:?}", foo, bar);
    let merged = Merged::new(foo, bar);
    println!("{:?}", merged);
    let (foo, bar) = merged.split();
    println!("{:?}, {:?}", foo, bar);
}
```

Error:

```
error: no rules expected the token `}`
  --> src/main.rs:11:9
   |
11 |         }
   |         ^ no rules expected this token in macro call
```